### PR TITLE
Build our docker image on Alma9

### DIFF
--- a/docker/Dockerfile.alma9
+++ b/docker/Dockerfile.alma9
@@ -1,0 +1,69 @@
+FROM almalinux:9
+
+# This is a start of the migration image in Alma9. Now waiting on Alma9 builds of CTA
+
+#ARG CTA_VERSION=4914961git25f327c0
+ARG CTA_VERSION=5-4956138git71bda8fb
+ARG CTA_JOB=26724272
+
+RUN dnf install -y 'dnf-command(config-manager)'
+RUN dnf config-manager --set-enabled crb
+RUN dnf install -y epel-release.noarch && \
+    dnf upgrade -y && \
+    dnf install -y \
+        python-pip \
+        git which nano wget gcc \
+        && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+ADD eos-xrootd-el9.repo /etc/yum.repos.d/eos-xrootd.repo
+#ADD oracle-instant-client-el9.repo /etc/yum.repos.d
+
+RUN wget https://public-yum.oracle.com/RPM-GPG-KEY-oracle-ol9 -O /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+
+RUN dnf -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+RUN dnf -y install postgresql14 postgresql14-libs
+ENV PATH="/usr/pgsql-14/bin:${PATH}"
+
+RUN dnf -y install  https://download.oracle.com/otn_software/linux/instantclient/1912000/oracle-instantclient19.12-basiclite-19.12.0.0.0-1.x86_64.rpm
+
+# Removed libarchive-devel
+RUN dnf install -y eos-client protobuf grpc-devel xrootd-client xrootd-client-libs libarchive \
+                   mt-st mtx lsscsi \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+# Why we have a version mis-match I don't know
+#RUN ln -s /opt/eos/xrootd/lib64/libXrdCl.so.2 /usr/lib64/libXrdCl.so.2
+
+# Good through here
+
+RUN pip install --upgrade protobuf sqlalchemy psycopg2-binary python-libarchive
+#RUN /opt/rh/rh-python38/root/usr/bin/pip3 install --upgrade protobuf sqlalchemy psycopg2 python-libarchive
+
+
+#RUN pip3 install --upgrade protobuf sqlalchemy psycopg2 python-libarchive
+
+# Install CEPH stuff
+#RUN rpm --import 'https://download.ceph.com/keys/release.asc'
+# libradosstriper1
+RUN dnf -y install librados2
+
+# Breaks here. No surprise CTA RPMs for EL7 don't install. Wait for EL9 RPMs
+
+#ADD tmp/cta-cli-4-4958535git71bda8fb.el7.cern.x86_64.rpm /root/cta-cli-4-4958535git71bda8fb.el7.cern.x86_64.rpm
+#ADD tmp/cta-lib-common-4-4958535git71bda8fb.el7.cern.x86_64.rpm /root/cta-common-4-4958535git71bda8fb.el7.cern.x86_64.rpm
+
+#RUN yum -y install /root/*.rpm
+
+# From here we want to remake the container as this code will change
+ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache
+RUN git clone https://github.com/ericvaandering/CTAEvaluation.git
+
+ADD cta-krb5.conf /etc/krb5.conf
+ADD cta-cli.conf /etc/cta/cta-cli.conf
+ADD cta-frontend-xrootd.conf /etc/cta/cta-frontend-xrootd.conf
+ADD eos.grpc.keytab /etc/cta/eos.grpc.keytab
+
+ADD entrypoint.sh /

--- a/docker/eos-xrootd-el9.repo
+++ b/docker/eos-xrootd-el9.repo
@@ -1,0 +1,17 @@
+[xrootd-stable]
+name=XRootD Stable repository
+baseurl=https://xrootd.slac.stanford.edu/binaries/stable/slc/7/$basearch http://xrootd.cern.ch/sw/repos/stable/slc/7/$basearch
+gpgcheck=1
+enabled=1
+protect=0
+gpgkey=http://xrootd.cern.ch/sw/releases/RPM-GPG-KEY.txt
+
+[eos-diopside]
+name=EOS 5.0 Version
+baseurl=https://storage-ci.web.cern.ch/storage-ci/eos/diopside/tag/testing/al-9/x86_64/
+gpgcheck=0
+
+[eos-diopside-dep]
+name=EOS 5.0 Dependencies
+baseurl=https://storage-ci.web.cern.ch/storage-ci/eos/diopside-depend/al-9/x86_64/
+gpgcheck=0

--- a/docker/oracle-instant-client-el9.repo
+++ b/docker/oracle-instant-client-el9.repo
@@ -1,0 +1,8 @@
+[oracle-instant-client]
+name=Oracle instant client
+baseurl=https://yum.oracle.com/repo/OracleLinux/OL9/oracle/instantclient/x86_64/
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+gpgcheck=1
+enabled=1
+priority=1
+


### PR DESCRIPTION
This doesn't work but gets most of the prerequisites. We still need Alma9 builds of CTA for one